### PR TITLE
fix: use full script url for install gobrew

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
         echo "$HOME/.gobrew/current/bin" >> $GITHUB_PATH
         echo "$HOME/.gobrew/bin"  >> $GITHUB_PATH
         echo "$HOME/go/bin"  >> $GITHUB_PATH
-        curl -sLk https://git.io/gobrew | sh -
+        curl -sLk https://raw.githubusercontent.com/kevincobain2000/gobrew/master/git.io.sh | sh
       shell: bash
 
     - name: gobrew use


### PR DESCRIPTION
[ref](https://github.blog/changelog/2022-04-25-git-io-deprecation/)

#1 